### PR TITLE
Different changes

### DIFF
--- a/src/bbt.js
+++ b/src/bbt.js
@@ -314,7 +314,7 @@ BBT.Connection.prototype.publish = function(args) {
 BBT.Connection.prototype.write = function(args) {
   var Channel = this.channels.getChannelWithPermission(args.channel, args.resource, false, true);
 
-  if(!Channel || Channel.hasWritePermission()) {
+  if(Channel && Channel.hasWritePermission()) {
     if(this.send('stream', 'write', {channel: args.channel, resource: args.resource, data: args.data})) {
       return args.callback({code: 0});
     } else {

--- a/src/bbt.js
+++ b/src/bbt.js
@@ -231,7 +231,7 @@ BBT.Connection.prototype.connect = function () {
   if( this.connection && this.connection.connected ) return this;
   var self = this;
   var query =  'key=' + this.bbt.key + '&username=' + (self.bbt.userinfo.username || '');
-  this.connection = io(self.bbt.getWsUrl(), {query: query });
+  this.connection = io(self.bbt.getWsUrl(), {query: query});
   this.connection.on('connect', function () {
     self.onConnection();
   });
@@ -300,11 +300,11 @@ BBT.Connection.prototype.unsubscribe = function(args) {
 
 BBT.Connection.prototype.publish = function(args) {
   var Channel = this.channels.getChannelWithPermission(args.channel, args.resource, false, true);
-  
+
   if(Channel && Channel.hasWritePermission()) {
     if(this.send('stream', 'emit', {channel: args.channel, resource: args.resource, data: args.data})) {
       return args.callback({code: 0});
-    }else {
+    } else {
       return args.callback({code: 11, message: 'Error while publishing message!'});
     }
   }
@@ -314,10 +314,10 @@ BBT.Connection.prototype.publish = function(args) {
 BBT.Connection.prototype.write = function(args) {
   var Channel = this.channels.getChannelWithPermission(args.channel, args.resource, false, true);
 
-  if(Channel && Channel.hasWritePermission()) {
+  if(!Channel || Channel.hasWritePermission()) {
     if(this.send('stream', 'write', {channel: args.channel, resource: args.resource, data: args.data})) {
       return args.callback({code: 0});
-    }else {
+    } else {
       return args.callback({code: 11, message: 'Error while writing message!'});
     }
   }
@@ -371,7 +371,7 @@ BBT.Channels.prototype.getChannelWithPermission = function(channel, resource, re
     if(read) match = Channel.hasReadPermission();
     if(write) match = Channel.hasWritePermission();
     if(match) return Channel;
-  }else if(Channel = this.channels[channel + '.*']) {
+  } else if (Channel = this.channels[channel + '.*']) {
     match = true;
     if(read) match = Channel.hasReadPermission();
     if(write) match = Channel.hasWritePermission();
@@ -455,8 +455,8 @@ BBT.Channel.prototype.do_subscribe = function() {
     if(connection.connection && connection.connection.connected && connection.connection.io.engine.id) {
       args.sid = connection.connection.io.engine.id;
       if(connection.bbt.auth_method === 'get') {
-        $.get( connection.bbt.auth_endpoint, args )
-        .success(function( data ) {
+        $.getJSON( connection.bbt.auth_endpoint, args) 
+        .done(function(data, status) {
           if(!data.auth) {
             return self.onError('Bad authentication reply');
           }
@@ -470,7 +470,7 @@ BBT.Channel.prototype.do_subscribe = function() {
             return false;
           }
         })
-        .error(function(XMLHttpRequest, textStatus, errorThrown) {
+        .fail(function(XMLHttpRequest, textStatus, errorThrown) {
           return self.onError('Unable to authenticate client');
         });
       }else if (connection.bbt.auth_method === 'post') {
@@ -508,7 +508,7 @@ BBT.Channel.prototype.do_subscribe = function() {
     } else {
       return self.onError('Connection error encountered');
     }
-  }else {
+  } else {
     if(connection.send('control', 'subscribe', args)) {
       self.subscribe();
       self.onSuccess('Successfully subscribed to ' + self.channel + '.' + self.resource);
@@ -691,7 +691,7 @@ BBT.prototype.subscribe = function(args, callback) {
   vargs.read = (typeof args.read === 'undefined' ) ? true : args.read === true; //default true
   vargs.write = args.write === true; // default false
   vargs.onError = args.onError || BBT.warn;
-  vargs.onSuccess = args.onSuccess || function() {};
+  vargs.onSuccess = args.onSuccess || function(msg) {console.log(msg);};
   vargs.is_public = args.is_public || false;
   var onError = vargs.onError;
 
@@ -720,7 +720,7 @@ BBT.prototype.unsubscribe = function(args) {
   vargs.channel = args.channel;
   vargs.resource = args.resource || '*';
   vargs.onError = args.onError || BBT.warn;
-  vargs.onSuccess = args.onSuccess || function() {};
+  vargs.onSuccess = args.onSuccess || function(msg) {console.log(msg);};
 
   if(!vargs.channel) return vargs.onError('channel not specified');
   if(!(typeof vargs.channel === 'string')) return vargs.onError('Invalid format: channel must be a string');

--- a/src/bbt.js
+++ b/src/bbt.js
@@ -300,11 +300,7 @@ BBT.Connection.prototype.unsubscribe = function(args) {
 
 BBT.Connection.prototype.publish = function(args) {
   var Channel = this.channels.getChannelWithPermission(args.channel, args.resource, false, true);
-  console.log(Channel);
-  console.log(args.channel);
-  console.log(args.resource);
-  console.log(args.data);
-
+  
   if(Channel && Channel.hasWritePermission()) {
     if(this.send('stream', 'emit', {channel: args.channel, resource: args.resource, data: args.data})) {
       return args.callback({code: 0});


### PR DESCRIPTION
Been trying to get this client to work properly in the browser, and noticed there are a couple of things that will need fixing to complete it.

**Added a warning when trying to subscribe and its not connected**
While working, I had instances whereby I was trying to setup the connection, and then subscribe immediately. As I was trying different api keys, I had no idea of telling if the connection had been established or not. After some internal debugging, I figured out the reason it subscribed sometimes and didn't was because I was trying to subscribe before the connection was established; and there was no warning to tell me this. So why I added this.  

**Added the ability to subscribe to public channels**
From all indications, it seems when using this client api, it is not allowed to subscribe to publish channels. Since I have to `auth_endpoint` yet in my application, I cannot work with private for now (unless I am wrong), and why I added the ability to instruct it using the `is_public` key, so it will allow to make use of public channels as well

**Added a key check when using empty string**
When I used an empty string as api key, it seemed to be it had connected and I couldn't tell if it had or not due to no enough information being sent to console to tell. So this helps with that

**Added setting on connection callback feature**
Initially when I was working with this api, as I was connecting and trying to subscribe immediately, it wasn't working as I really had no way to know if it had connected or not. Within the `bbt.js` file, it does have an `onConnection` callback, but this was no available for one to use for other things (unless I am wrong, so forgive my noob level ;)). So added the ability to specify a callback, which will be ran when a connection is made. This will then allow the user to do other things which needs connection like subscribe to channels and all.
 
**Added setting on disconnection callback feature**
Similar to the above but for disconnection this time. Even internally this was disregarded, so had to add it so users can use the callback to do other stuffs when writting code

**Disable auto connect by default**
Auto connecting by default, didn't allow for time to do other things before the connection is made, like specifying an `on_connect` or `on_disconnect` callback

**Added the ability to set if the channel is public or not using `is_public`**
This became necessary as it seems the client api is only designed to connect to private channels, when the `write` is enabled. I can understand the reason for extra security, but not everyone has all the backend infrastructure to setup the connection endpoint. Besides my app is to run in standalone mode as a PWA, so there is no way I will be using an authentication url

**Fix for a few bugs**
- Fixed jquery authentication
- Fixed error returned when authenticating 

Documentation will need more explanation in general, if my PR is accepted and will be willing to help with that.

Regards